### PR TITLE
Clarify that an image operator can be applied to several images

### DIFF
--- a/include/command-line-processing.php
+++ b/include/command-line-processing.php
@@ -286,7 +286,7 @@ any command-line <a href="<?php echo $_SESSION['RelativePath']?>/../script/comma
 <a href="#setting">image setting</a> or
 <a href="#sequence">image sequence operator</a>.  Unlike an
 image setting, which persists until the command-line terminates,
-an operator is applied to an image and forgotten.  The image operators
+an operator is applied to the current images and forgotten.  The image operators
 include:</p>
 
 <ul>


### PR DESCRIPTION
If the current image stack has several images which forms an image
sequence, an image operator will be applied to all the images.

This resolves #13. See the discussion in #11, beginning from https://github.com/ImageMagick/Website/pull/11#issuecomment-372157170.