### PR TITLE
Fix  'heic:preserve-orientation' 

### DIFF
--- a/include/command-line-options.php
+++ b/include/command-line-options.php
@@ -1929,7 +1929,7 @@ available:</p>
   </tr>
 
   <tr>
-    <td>heic:preserve-orientation</td>
+    <td>heic:preserve-orientation=true</td>
     <td>Preserve the original EXIF orientation during HEIC decoding and rotate the pixels accordingly.
         By default, EXIF orientation is reset to "1" to match the actual orientation of pixels in HEIC.
     </td>


### PR DESCRIPTION
Fix description of command line option 'heic:preserve-orientation'  introduced in https://github.com/ImageMagick/ImageMagick/pull/1233