### PR TITLE
Add default output description for identify

### DIFF
--- a/include/identify.php
+++ b/include/identify.php
@@ -11,6 +11,10 @@
 rose.jpg JPEG 70x46 70x46+0+0 8-bit sRGB 2.36KB 0.000u 0:00.000
 </code></pre>
 
+<p>By default, <code>identify</code> provides the following output:</p>
+
+<p><code>Filename[frame #] image-format widthxheight page-widthxpage-height+x-offset+y-offset colorspace user-time elapsed-time</code></p>
+
 <p>Next, we look at the same image in greater detail:</p>
 
 <pre class="pre-scrollable"><code>-> magick identify -verbose rose.jpg


### PR DESCRIPTION
The example for identify's default output had no labels identifying the various fields.

Related: ImageMagick/ImageMagick#1504