### PR TITLE
Mention -define pango:align

### DIFF
--- a/include/formats.php
+++ b/include/formats.php
@@ -1319,7 +1319,7 @@ the supported image formats.</p>
     <td>PANGO</td>
     <td>R</td>
     <td>Image caption</td>
-    <td>You can configure the caption layout with these defines: <code>-define pango:auto-dir=</code><var>true/false</var>, <code>-define pango:ellipsize=</code><var>start/middle/end</var>, <code>-define pango:gravity-hint=</code><var>natural/strong/line</var>, <code>-define pango:hinting=</code><var>none/auto/full</var>, <code>-define pango:indent=</code><var>points</var>, <code>-define pango:justify=</code><var>true/false</var>, <code>-define pango:language=</code><var>en_US/etc</var>, <code>-define pango:markup=</code><var>true/false</var>, <code>-define pango:single-paragraph=</code><var>true/false</var> and <code>-define pango:wrap=</code><var>word/char/word-char</var>.</td>
+    <td>You can configure the caption layout with these defines: <code>-define pango:auto-dir=</code><var>true/false</var>, <code>-define pango:ellipsize=</code><var>start/middle/end</var>, <code>-define pango:gravity-hint=</code><var>natural/strong/line</var>, <code>-define pango:hinting=</code><var>none/auto/full</var>, <code>-define pango:indent=</code><var>points</var>, <code>-define pango:justify=</code><var>true/false</var>, <code>-define pango:language=</code><var>en_US/etc</var>, <code>-define pango:markup=</code><var>true/false</var>, <code>-define pango:single-paragraph=</code><var>true/false</var>, <code>-define pango:wrap=</code><var>word/char/word-char</var> and <code>-define pango:align=</code><var>left/center/right</var>.</td>
   </tr>
 
   <tr>


### PR DESCRIPTION
I spend a good deal of time today trying to get right alignment to work with pango; I used `-gravity` but I had strange results since my emojis were rotated (see below).

Now that I saw https://github.com/ImageMagick/ImageMagick/issues/1488 I wanted to help the rest of the world see this :heart: 

I am considering updating the [Pango part of 'Text to Image Handling' in the examples](https://github.com/ImageMagick/usage-markdown/blob/a933c922d882bbfde0341f7636a4720f89f551d7/text/index.md#pango-notes-and-problems-pango_notes), however that repo has been updated last in 2016. Do you have an idea if a pull request would even be considered if I made one today? or is there a better place to add an example for ImageMagick v7?

<details>

### using gravity

`convert -gravity West -background '#CCCCCC' pango:'line number one\nno. 2 😀' gravity-west.png`

![gravity-west](https://user-images.githubusercontent.com/1054041/55485811-751e1900-562b-11e9-8b8e-6afa23a6eb0c.png)

### using align

`convert -background '#CCCCCC' -define pango:align=right pango:'line number one\nno. 2 😀' align-right.png`

![align-right](https://user-images.githubusercontent.com/1054041/55485947-ba424b00-562b-11e9-9871-887e9fcb1239.png)
</details>