### PR TITLE
Fix word repetition in advanced-unix-installation.php

### DIFF
--- a/include/advanced-unix-installation.php
+++ b/include/advanced-unix-installation.php
@@ -426,7 +426,7 @@ identify logo.gif
 <pre class="highlight"><code>make check
 </code></pre>
 
-<p>Ghostscript is a prerequisite, otherwise the EPS, PS, and PDF tests will fail.  Note that due to differences between the developer's environment and your own it is possible that a few tests may fail even though the results are ok. Differences between the developer's environment environment and your own may include the compiler, the CPU type, and the library versions used. The ImageMagick developers use the current release of all dependent libraries.</p>
+<p>Ghostscript is a prerequisite, otherwise the EPS, PS, and PDF tests will fail.  Note that due to differences between the developer's environment and your own it is possible that a few tests may fail even though the results are ok. Differences between the developer's environment and your own may include the compiler, the CPU type, and the library versions used. The ImageMagick developers use the current release of all dependent libraries.</p>
 
 <h2><a class="anchor" id="linux"></a>Linux-specific Build instructions</h2>
 


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/Website/pulls) open

### Description
I deleted the word **environment** which was unexpectedly repeated.