### PR TITLE
Fix word repetition in dither command line option description

### DIFF
--- a/include/command-line-options.php
+++ b/include/command-line-options.php
@@ -3150,7 +3150,7 @@ a lower level pattern of colors. Error diffusion dithers can use any set of
 colors (generated or user defined) to an image.  </p>
 
 <p>Dithering is turned on by default, to turn it off use the plus form of the
-setting, <a href="#dither">+dither</a>. This will also also render PostScript
+setting, <a href="#dither">+dither</a>. This will also render PostScript
 without text or graphic aliasing. Disabling dithering often (but not always)
 leads to faster process, a smaller number of colors, but more cartoon like
 image coloring.  Generally resulting in 'color banding' effects in areas with


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/Website/pulls) open

### Description
I deleted the word **also** which was unexpectedly repeated.