### PR TITLE
Fix word repetition in Enumerations.html CompositeOperator OverCompositeOp

### DIFF
--- a/Magick++/Enumerations.html
+++ b/Magick++/Enumerations.html
@@ -453,7 +453,7 @@ Specify <i>CompositeOperator</i> to select a different algorithm.
 			<p>OverCompositeOp</p>
 		</td>
 		<td>
-			<p>The result is the union of the the two image shapes with the
+			<p>The result is the union of the two image shapes with the
 			<i>composite image</i> obscuring <i>image</i> in the region of
 			overlap.</p>
 		</td>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/Website/pulls) open

### Description
I deleted the word **and** which was unexpectedly repeated.