### PR TITLE
Fix word repetition in Image++ display method description

### DIFF
--- a/Magick++/Image++.html
+++ b/Magick++/Image++.html
@@ -895,7 +895,7 @@ image.write("myImage.tiff");
                         <font size="-1">Display image on screen.</font> <br />
                         <font size="-1">
                             <b><font color="#ff0000">Caution: </font></b> if
-                            an image format is is not compatible with the display visual (e.g.
+                            an image format is not compatible with the display visual (e.g.
                             JPEG on a colormapped display) then the original image will be
                             altered. Use a copy of the original if this is a problem.
                         </font>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/Website/pulls) open

### Description
I deleted the word **is** which was unexpectedly repeated.