### PR TITLE
Fix word repetition in TypeMetric.html descent method description

### DIFF
--- a/Magick++/TypeMetric.html
+++ b/Magick++/TypeMetric.html
@@ -52,7 +52,7 @@ size_points = (size_pixels * 72)/resolution
 <td>
 <p><font size="2">void</font></p></td>
 <td>
-<p><font size="2">Returns the the distance in pixels from the baseline to the lowest grid coordinate used to place an outline point. Always a negative value.</font></p></td></tr>
+<p><font size="2">Returns the distance in pixels from the baseline to the lowest grid coordinate used to place an outline point. Always a negative value.</font></p></td></tr>
 <tr>
 <td>
 <p align="center"><a name="textWidth"></a><font size="2">textWidth</font></p></td>


### PR DESCRIPTION
### Prerequisites

- [x] I have written a descriptive pull-request title
- [x] I have verified that there are no overlapping [pull-requests](https://github.com/ImageMagick/Website/pulls) open

### Description
I deleted the word **the** which was unexpectedly repeated.