### PR TITLE
Update high-dynamic-range.php

### DIFF
--- a/include/high-dynamic-range.php
+++ b/include/high-dynamic-range.php
@@ -22,7 +22,7 @@
 <pre class="highlight"><code>./configure --disable-hdri
 </code></pre>
 
-<p>Under Windows, uncomment the <code>MAGICKCORE_HDRI_SUPPORT</code> definition in the <code>magick-baseconfig.h</code> configuration file and build.</p>
+<p>Under Windows, follow the instructions (straightforward for a non-programmer) in a one hour process to build and configure your own executables: <a href="https://imagemagick.org/script/install-source.php">Install from Windows Source</a>.</p>
 
 <p>To verify HDRI is properly configured, look for "HDRI" as a feature:</p>
 


### PR DESCRIPTION
Line 25: the instruction "uncomment the MAGICKCORE_HDRI_SUPPORT definition in the magick-baseconfig.h configuration file" is outdated, since that file does not exist  in 7.0.9-22.  The comment "(straightforward for a non-programmer)" might seem obvious to an expert, but because I had never done this before I was nervous and uncertain - I hope this comment will reassure non-experts. The link to https://imagemagick.org/script/install-source.php is useful since I could only find it with a search on github. 