### PR TITLE
Added info for FLIF

### DIFF
--- a/include/formats.php
+++ b/include/formats.php
@@ -367,6 +367,13 @@ the supported image formats.</p>
   </tr>
 
   <tr>
+    <td><a href="https://flif.info/">FLIF</a></td>
+    <td>RW</td>
+    <td>Free Lossless Image Format</td>
+    <td></td>
+  </tr>
+   
+  <tr>
     <td>FPX</td>
     <td>RW</td>
     <td>FlashPix Format</td>


### PR DESCRIPTION
Just adding info for FLIF to the formats page. It's been included with ImageMagick for a few years, but wasn't in the list. I left the "Notes" column blank, but someone more knowledgeable might want to add a note about the needed FLIF dependencies and versioning there.