### PR TITLE
Remove link to outdated JXL spec 

### DIFF
--- a/include/formats.php
+++ b/include/formats.php
@@ -557,7 +557,7 @@ the supported image formats.</p>
   <tr>
     <td><a href="https://jpeg.org/jpegxl">JXL</a></td>
     <td>RW</td>
-    <td><a href="https://arxiv.org/ftp/arxiv/papers/1908/1908.03565.pdf">JPEG XL image coding system</a></td>
+    <td>JPEG XL image coding system</td>
     <td>Requires the <a href="https://gitlab.com/wg1/jpeg-xl.git">JPEG XL</a> delegate library.</td>
   </tr>
 


### PR DESCRIPTION
The link was to a now-outdated committee draft of the specification, which is quite far from the final specification.