### PR TITLE
Update heic -define doc

### DIFF
--- a/include/defines.php
+++ b/include/defines.php
@@ -809,7 +809,7 @@ use:</p>
 
   <tr>
     <td>heic:chroma=<var>value</var></td>
-    <td>set the HEIC chroma parameter.</td>
+    <td>set the HEIC chroma parameter. Possible values are: "420", "422", "444". Default is "420".</td>
     </td>
   </tr>
 
@@ -821,7 +821,7 @@ use:</p>
 
   <tr>
     <td>heic:speed=<var>value</var></td>
-    <td>set the HEIC speed parameter.</td>
+    <td>set the HEIC speed parameter. Integer value from 0-9. Default is 5.</td>
     </td>
   </tr>
 


### PR DESCRIPTION
Added defaults and valid values for heic parameters.

Sources:
- heic:chroma
  - [default](https://github.com/strukturag/libheif/blob/1d36c10ade9b2acfc2dcc4ca8b6176a9789c902c/libheif/heif_encoder_aom.cc#L244)
  - [valid values](https://github.com/strukturag/libheif/blob/1d36c10ade9b2acfc2dcc4ca8b6176a9789c902c/libheif/heif_encoder_aom.cc#L136-L138)
- heic:speed
  - [default](https://github.com/strukturag/libheif/blob/1d36c10ade9b2acfc2dcc4ca8b6176a9789c902c/libheif/heif_encoder_aom.cc#L191)
  - [valid values](https://github.com/strukturag/libheif/blob/1d36c10ade9b2acfc2dcc4ca8b6176a9789c902c/libheif/heif_encoder_aom.cc#L194-L201)