### PR TITLE
command-line-options: add missing close-quote

### DIFF
--- a/include/command-line-options.php
+++ b/include/command-line-options.php
@@ -1277,7 +1277,7 @@ flag. </p>
 
 <p>For example <a href="#threshold">-threshold</a> will by default grayscale
 the image before thresholding, if no <a href="#channel" >-channel</a> setting
-has been defined. This is not 'Sync flag controlled, yet. </p>
+has been defined. This is not 'Sync' flag controlled, yet. </p>
 
 <p>Also some operators such as <a href="#blur">-blur</a>, <a
 href="#gaussian-blur">-gaussian-blur</a>, will modify their handling of the


### PR DESCRIPTION
An incredibly minor typo fix. Reading on the web, I happened to notice an unclosed quote around the "Sync" in "`'Sync flag`", one of the times it was mentioned. (Well, once I figured out that it meant `'Sync' flag`.)