### PR TITLE
Add missing T to QOI format name

### DIFF
--- a/include/formats.php
+++ b/include/formats.php
@@ -982,7 +982,7 @@ the supported image formats.</p>
   <tr>
     <td><a href="https://qoiformat.org/">QOI</a></td>
     <td>RW</td>
-    <td>Quite OK Image Forma</td>
+    <td>Quite OK Image Format</td>
     <td>Fast, lossless image compression.</td>
   </tr>
 


### PR DESCRIPTION
It turns out QUI is a [method of organizing data](https://www.merriam-webster.com/dictionary/format), not a [distinguishable group of organisms](https://www.merriam-webster.com/dictionary/forma).