### PR TITLE
Fix image constructor documentation

### DIFF
--- a/Magick++/Enumerations.html
+++ b/Magick++/Enumerations.html
@@ -2184,10 +2184,18 @@ destination pixel array.
 	</tr>
 	<tr>
 		<td>
-			<p>IntegerPixel</p>
+			<p>LongPixel</p>
 		</td>
 		<td>
-			<p>Integer type</p>
+			<p>Long integer type</p>
+		</td>
+	</tr>
+	<tr>
+		<td>
+			<p>LongLongPixel</p>
+		</td>
+		<td>
+			<p>Long long integer type</p>
 		</td>
 	</tr>
 	<tr>

--- a/Magick++/Image++.html
+++ b/Magick++/Image++.html
@@ -381,10 +381,10 @@ image.read( blob);
                                     <td><font size="-1">map_</font></td>
                                     <td>
                                         <font size="-1">
-                                            This character string can be any
-                                            combination or order of R = red, G = green, B = blue, A = alpha, C =
-                                            cyan, Y = yellow M = magenta, and K = black. The ordering reflects the
-                                            order of the pixels in the supplied pixel array.
+                                            This character string can be any combination or order of R = red, G =
+                                            green, B = blue, A = alpha, O = opacity, C = cyan, Y = yellow, M =
+                                            magenta, K = black, I = intensity, and P = pad. The ordering reflects
+                                            the order of the pixels in the supplied pixel array.
                                         </font>
                                     </td>
                                 </tr>
@@ -395,7 +395,7 @@ image.read( blob);
                                             <a href="Enumerations.html#StorageType">
                                                 Pixel
                                                 storage type
-                                            </a> (CharPixel, ShortPixel, IntegerPixel, FloatPixel, or
+                                            </a> (CharPixel, ShortPixel, LongPixel, LongLongPixel, FloatPixel, or
                                             DoublePixel)
                                         </font>
                                     </td>
@@ -1785,10 +1785,10 @@ image.write("myImage.tiff");
                                     <td><font size="-1">map_</font></td>
                                     <td>
                                         <font size="-1">
-                                            This character string can be any
-                                            combination or order of R = red, G = green, B = blue, A = alpha, C =
-                                            cyan, Y = yellow M = magenta, and K = black. The ordering reflects the
-                                            order of the pixels in the supplied pixel array.
+                                            This character string can be any combination or order of R = red, G =
+                                            green, B = blue, A = alpha, O = opacity, C = cyan, Y = yellow, M =
+                                            magenta, K = black, I = intensity, and P = pad. The ordering reflects
+                                            the order of the pixels in the supplied pixel array.
                                         </font>
                                     </td>
                                 </tr>
@@ -1797,7 +1797,7 @@ image.write("myImage.tiff");
                                     <td>
                                         <font size="-1">
                                             Pixel storage type (CharPixel,
-                                            ShortPixel, IntegerPixel, FloatPixel, or DoublePixel)
+                                            ShortPixel, LongPixel, LongLongPixel, FloatPixel, or DoublePixel)
                                         </font>
                                     </td>
                                 </tr>
@@ -2386,9 +2386,9 @@ image.write("myImage.tiff");
                                     <td><font size="-1">map_</font></td>
                                     <td>
                                         <font size="-1">
-                                            This character string can be any
-                                            combination or order of R = red, G = green, B = blue, A = alpha, C =
-                                            cyan, Y = yellow, M = magenta, and K = black. The ordering reflects
+                                            This character string can be any combination or order of R = red, G =
+                                            green, B = blue, A = alpha, O = opacity, C = cyan, Y = yellow, M =
+                                            magenta, K = black, I = intensity, and P = pad. The ordering reflects
                                             the order of the pixels in the supplied pixel array.
                                         </font>
                                     </td>
@@ -2398,7 +2398,7 @@ image.write("myImage.tiff");
                                     <td>
                                         <font size="-1">
                                             Pixel storage type (CharPixel,
-                                            ShortPixel, IntegerPixel, FloatPixel, or DoublePixel)
+                                            ShortPixel, LongPixel, LongLongPixel, FloatPixel, or DoublePixel)
                                         </font>
                                     </td>
                                 </tr>


### PR DESCRIPTION
According the links below, the storage type and pixel map need an update for the Image constructor:
https://github.com/ImageMagick/ImageMagick/blob/2a69677d2e41292f23938073c3a2b78380f7d5ed/MagickCore/constitute.c#L201
https://github.com/ImageMagick/ImageMagick/blob/2a69677d2e41292f23938073c3a2b78380f7d5ed/MagickCore/pixel.c#L4197
https://github.com/ImageMagick/ImageMagick/blob/2a69677d2e41292f23938073c3a2b78380f7d5ed/MagickCore/pixel.h#L154