### PR TITLE
Fix typo "substracting" in docs/defines/index.html

### DIFF
--- a/docs/defines/index.html
+++ b/docs/defines/index.html
@@ -1508,7 +1508,7 @@ use:</p>
     <td>tiff:predictor=<var>[1, 2 or 3]</var></td>
     <td>A mathematical operator that is applied to the image data before an
     encoding scheme is applied. The general idea is that subsequent pixels of
-    an image resemble each other. Thus, substracting the information from a
+    an image resemble each other. Thus, subtracting the information from a
     pixel that is already contained in previous one is likely to reduce its
     information density considerably and aid subsequent compression.
     1 = No prediction scheme used before coding. 2 = Horizontal differencing.


### PR DESCRIPTION
Fix typo `substracting` to `subtracting` in docs/defines/index.html