### PR TITLE
Fix typo "fo rthe" in docs/command-line-options

### DIFF
--- a/docs/command-line-options/index.html
+++ b/docs/command-line-options/index.html
@@ -6934,7 +6934,7 @@ middle-gray; 100% is black). </p>
 <p>To achieve the equivalent of a sigmoidal brightness change (similar to
 a gamma adjustment), you would use <var>-sigmoidal-contrast
 {brightness}x0%</var> to increase brightness and <var>+sigmoidal-contrast {brightness}x0%</var> to decrease brightness.
-Note the use of '0' fo rthe mid-point of the sigmoidal curve. </p>
+Note the use of '0' for the mid-point of the sigmoidal curve. </p>
 
 <p>Using a very high <var>contrast</var> will produce a sort of
 'smoothed thresholding' of the image.  Not as sharp (with high aliasing


### PR DESCRIPTION
Fix typo `fo rthe` to `for the` in docs/command-line-options/index.html