### PR TITLE
Fix jinc formula

### DIFF
--- a/docs/fx/index.html
+++ b/docs/fx/index.html
@@ -271,7 +271,7 @@ description: "Explore ImageMagick’s FX special effects operator, a powerful pi
 <dt class="col-md-4"> <code>isnan(</code><var>x</var><code>)</code></dt><dd class="col-md-8">return 1.0 if <var>x</var> is NAN, 0.0 otherwise</dd>
 <dt class="col-md-4"> <code>j0(</code><var>x</var><code>)</code></dt><dd class="col-md-8"> Bessel functions of <var>x</var> of the first kind of order 0</dd>
 <dt class="col-md-4"> <code>j1(</code><var>x</var><code>)</code></dt><dd class="col-md-8"> Bessel functions of <var>x</var> of the first kind of order 1</dd>
-<dt class="col-md-4"> <code>jinc(</code><var>x</var><code>)</code></dt><dd class="col-md-8"> jinc function (max=1, min=-0.1323); jinc(<var>x</var>)=2*j1(pi*<var>x</var>)/(pi*<var>*x</var>)</dd>
+<dt class="col-md-4"> <code>jinc(</code><var>x</var><code>)</code></dt><dd class="col-md-8"> jinc function (max=1, min=-0.1323); jinc(<var>x</var>)=2*j1(pi*<var>x</var>)/(pi*<var>x</var>)</dd>
 <dt class="col-md-4"> <code>ln(</code><var>x</var><code>)</code></dt><dd class="col-md-8"> natural logarithm function</dd>
 <dt class="col-md-4"> <code>log(</code><var>x</var><code>)</code></dt><dd class="col-md-8"> logarithm base 10</dd>
 <dt class="col-md-4"> <code>logtwo(</code><var>x</var><code>)</code></dt><dd class="col-md-8"> logarithm base 2</dd>


### PR DESCRIPTION
The jinc formula has an extra asterisk on the fx page.

Note the official code shows the extra asterisk does not exist.
https://github.com/ImageMagick/ImageMagick/blob/main/MagickCore/fx.c#L3630-L3633

Also the `airy` function on the same page shows the correct form of the jinc function (note there is no extra asterisk in the denominator).

For additional reference regarding the Jinc function, I also consulted:
https://mathworld.wolfram.com/JincFunction.html
which also confirms the correction is appropriate.
