### PR TITLE
Fix RGB to sRGB conversion formulas in Command-line Options page

### DIFF
--- a/docs/command-line-options/index.html
+++ b/docs/command-line-options/index.html
@@ -1725,10 +1725,11 @@ for CMYKA (or RGBA with offsets).  The matrix is similar to
         <tr><td valign="middle">Y=0.212656*R+0.715158*G+0.072186*B; <var>intensity-like</var></td></tr>
         <tr><td valign="middle">Cb=(−0.114572*R−0.385428*G+0.500000*B)+(<var>QuantumRange</var>+1)/2</td></tr>
         <tr><td valign="middle">Cr=(0.500000*R−0.454153*G−0.045847*B)+(<var>QuantumRange</var>+1)/2</td></tr>
+        
         <tr><th valign="middle">sRGB</th></tr>
-        <tr><td valign="middle">if R ≤ .0.0031308 then Rs=R/12.92 else Rs=1.055 R ^ (1.0 / 2.4) - 0.055</td></tr>
-        <tr><td valign="middle">if G ≤ .0.0031308 then Gs=B/12.92 else Gs=1.055 R ^ (1.0 / 2.4) - 0.055</td></tr>
-        <tr><td valign="middle">if B ≤ .0.0031308 then Bs=B/12.92 else Bs=1.055 R ^ (1.0 / 2.4) - 0.055</td></tr>
+        <tr><td valign="middle">if R ≤ 0.0031307 then Rs=12.92*R else Rs=1.055 R ^ (1.0 / 2.4) - 0.055</td></tr>
+        <tr><td valign="middle">if G ≤ 0.0031307 then Gs=12.92*G else Gs=1.055 G ^ (1.0 / 2.4) - 0.055</td></tr>
+        <tr><td valign="middle">if B ≤ 0.0031307 then Bs=12.92*B else Bs=1.055 B ^ (1.0 / 2.4) - 0.055</td></tr>
 
         <tr><th valign="middle">XYZ</th></tr>
         <tr><td valign="middle">X=0.4124564*R+0.3575761*G+0.1804375*B</td></tr>


### PR DESCRIPTION
In the process of fixing typos in the Command-line Options page, I found the formulas for converting RGB to sRGB need additional corrections:
* Remove extra decimal dot in front of `.0.0031308` to `0.0031308` 
* Correct rounding of `0.0031308` to `0.0031307` to match source code
* Corrected usage of R, G, and B variables (each channel should have matching Rs/R Gs/G, Bs/B variables)
* Based on source code, corrected 12.92 from division to multiplication

Source code involved:
https://github.com/ImageMagick/ImageMagick/blob/main/MagickCore/pixel.c#L445-L451

The source code includes usage of `QuantumRange` and `QuantumScale`, but those cancel out properly to match the documentation here as written.