### PR TITLE
Remove duplicate quiet option for Import

### DIFF
--- a/docs/import/index.html
+++ b/docs/import/index.html
@@ -247,11 +247,6 @@ title: "Command-line Tools: Import"
   </tr>
 
   <tr>
-    <td><a href="/command-line-options/#quiet">-quiet</a></td>
-    <td>suppress all warning messages</td>
-  </tr>
-
-  <tr>
     <td><a href="/command-line-options/#regard-warnings">-regard-warnings</a></td>
     <td>pay attention to warning messages.</td>
   </tr>


### PR DESCRIPTION
Remove duplicate `-quiet` option on "import" page