### PR TITLE
Remove obsolete and broken installation tutorial links

### DIFF
--- a/docs/links/index.html
+++ b/docs/links/index.html
@@ -2,7 +2,7 @@
 title: "Related Web Sites"
 ---
 <div>
-<p class="text-center"><a href="#command-line">Command-line Tutorials</a> • <a href="#program-interfaces">Program Interface Tutorials</a> • <a href="#techniques">ImageMagick Techniques</a> • <a href="#install">Installation Tutorials</a> • <a href="#topics">ImageMagick Topics</a> • <a href="#book-review">ImageMagick Book Review</a> • <a href="#mirrors">Web Site Mirrors</a> • <a href="#bank">Image Bank</a> • <a href="#related-projects">Related Projects</a></p>
+<p class="text-center"><a href="#command-line">Command-line Tutorials</a> • <a href="#program-interfaces">Program Interface Tutorials</a> • <a href="#techniques">ImageMagick Techniques</a> • <a href="#topics">ImageMagick Topics</a> • <a href="#book-review">ImageMagick Book Review</a> • <a href="#mirrors">Web Site Mirrors</a> • <a href="#bank">Image Bank</a> • <a href="#related-projects">Related Projects</a></p>
 
 <p class="lead">Listed here are a number of external web sites that are related to ImageMagick.  ImageMagick Studio does not maintain or endorse most of these sites, but we feel they are a helpful adjunct to the ImageMagick project.</p>
 
@@ -32,15 +32,6 @@ title: "Related Web Sites"
   <dd class="col-md-8"><a href="https://rmagick.github.io/rvgtut.html">RVG - Ruby Vector Graphics</a></dd>
   <dd class="col-md-8"><a href="http://www.devshed.com/c/a/PHP/Security-Images-with-PHP-and-ImageMagick/">Security Images with PHP and ImageMagick</a></dd>
   <dd class="col-md-8"><a href="http://php.net/manual/en/imagick.examples-1.php">Basic Uses of ImageMagick With PHP</a></dd>
-</ul>
-
-<h2><a class="anchor" id="install"></a>Installation Tutorials</h2>
-
-<ul>
-  <dd class="col-md-8"><a href="http://cactuslab.com/imagemagick/">ImageMagick Installer for Mac OS X</a></dd>
-  <dd class="col-md-8"><a href="https://www.cloudgoessocial.net/2011/03/21/im-xcode4-ios4-3/">ImageMagick on iPhone</a></dd>
-  <dd class="col-md-8"><a href="https://github.com/juan-cardelino/imagemagick_lib_iphone/">Scripts and Instructions to Compile ImageMagick as an iOS Static Library</a></dd>
-  <dd class="col-md-8"><a href="http://www.digitalsanctum.com/2009/03/18/installing-imagemagick-from-source-on-ubuntu-804/">Installing ImageMagick from Source on Ubuntu</a></dd>
 </ul>
 
 <h2><a class="anchor" id="techniques"></a>ImageMagick Techniques</h2>


### PR DESCRIPTION
## Description
Removes the "Installation Tutorials" section of Related Web Sites. This fixes a subset of the links identified in #158.

## Review of Links
- http://cactuslab.com/imagemagick/ = 404 not found (no suitable replacement)
- https://www.cloudgoessocial.net/2011/03/21/im-xcode4-ios4-3/ = Domain now hosts online casino spam
- https://github.com/juan-cardelino/imagemagick_lib_iphone/ = GitHub repo last updated 11 years ago. Obsolete.
- http://www.digitalsanctum.com/2009/03/18/installing-imagemagick-from-source-on-ubuntu-804/ = 404 not found (no suitable replacement)
